### PR TITLE
Update @tak-ps/etl to v9.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,10 @@
         "": {
             "name": "etl-aprs",
             "version": "1.0.0",
-            "license": "MIT",
+            "license": "AGPL-3.0-only",
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0",
-                "@tak-ps/etl": "^9.9.0"
+                "@tak-ps/etl": "^9.22.0"
             },
             "devDependencies": {
                 "@types/geojson": "^7946.0.10",
@@ -1028,6 +1028,13 @@
                 "node": ">= 18"
             }
         },
+        "node_modules/@orbat-mapper/convert-symbology": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@orbat-mapper/convert-symbology/-/convert-symbology-1.0.2.tgz",
+            "integrity": "sha512-FpnPXS16/C+ay7FVPLhTkRH2NmREKxhJ+pifqcW9NpsbORH94S14qU8Eyl2ofMP7upxQYNvw2qpTok5I3P4QKw==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1687,9 +1694,9 @@
             }
         },
         "node_modules/@tak-ps/etl": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/etl/-/etl-9.18.0.tgz",
-            "integrity": "sha512-lSfF1d39Y++mzf1w70WT1NS9NzwUOCG0RHU46Hvn/6+cGA0p4QK040ot1EfZ2LTakOe+/Rv1BT7ymwlZzd1vuQ==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/etl/-/etl-9.24.0.tgz",
+            "integrity": "sha512-6SjpNJcbhYiRrgyfBjbCO1pxZGnlGbSoXjkxwAcdSDV7VvTOR4oYiMlCo0/EUZbL3fHTyYviadve6WJlrWHNFQ==",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-secrets-manager": "^3.828.0",
@@ -1709,17 +1716,18 @@
                 "node": ">= 22"
             },
             "peerDependencies": {
-                "@tak-ps/node-cot": "^13.2.0"
+                "@tak-ps/node-cot": "^14.1.0"
             }
         },
         "node_modules/@tak-ps/node-cot": {
-            "version": "13.6.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-13.6.0.tgz",
-            "integrity": "sha512-YGnzKwfe57t7wS1hftQH1p4DMpVm7pjGwUeJTJ3FG/SIn7CPgrauK8aa68X4NPvvgST3dnmWMbtbf2RHlKe+DQ==",
+            "version": "14.12.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/node-cot/-/node-cot-14.12.0.tgz",
+            "integrity": "sha512-JHlBiBVXuyBbySDFgFPjpvUEzzfuxNgmC8qh87wDkK0B8A0tFm1NviASkZF3/ucb2L63w6gI9kg8vWdiEFAeiA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@openaddresses/batch-error": "^2.4.0",
+                "@orbat-mapper/convert-symbology": "^1.0.2",
                 "@sinclair/typebox": "^0.34.0",
                 "@turf/destination": "^7.2.0",
                 "@turf/ellipse": "^7.0.0",
@@ -1738,7 +1746,7 @@
                 "node-stream-zip": "^1.15.0",
                 "protobufjs": "^7.3.0",
                 "rimraf": "^6.0.0",
-                "uuid": "^11.1.0",
+                "uuid": "^13.0.0",
                 "xml-js": "^1.6.11"
             },
             "engines": {
@@ -1746,9 +1754,9 @@
             }
         },
         "node_modules/@tak-ps/node-cot/node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+            "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
@@ -1756,7 +1764,7 @@
             "license": "MIT",
             "peer": true,
             "bin": {
-                "uuid": "dist/esm/bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/@tak-ps/serverless-http": {
@@ -2161,9 +2169,9 @@
             }
         },
         "node_modules/@types/archiver": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
-            "integrity": "sha512-a6wUll6k3zX6qs5KlxIggs1P1JcYJaTCx2gnlr+f0S1yd2DoaEwoIK10HmBaLnZwWneBz+JBm0dwcZu0zECBcQ==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
+            "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -2884,11 +2892,19 @@
             "peer": true
         },
         "node_modules/b4a": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+            "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
             "license": "Apache-2.0",
-            "peer": true
+            "peer": true,
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -2897,12 +2913,19 @@
             "license": "MIT"
         },
         "node_modules/bare-events": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.0.tgz",
-            "integrity": "sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.1.tgz",
+            "integrity": "sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true
+            "peer": true,
+            "peerDependencies": {
+                "bare-abort-controller": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -3100,9 +3123,9 @@
             }
         },
         "node_modules/color": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/color/-/color-5.0.0.tgz",
-            "integrity": "sha512-16BlyiuyLq3MLxpRWyOTiWsO3ii/eLQLJUQXBSNcxMBBSnyt1ee9YUdaozQp03ifwm5woztEZGDbk9RGVuCsdw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
+            "integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -3114,9 +3137,9 @@
             }
         },
         "node_modules/color-convert": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
-            "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
+            "integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -3127,9 +3150,9 @@
             }
         },
         "node_modules/color-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
-            "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
+            "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -3137,9 +3160,9 @@
             }
         },
         "node_modules/color-string": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.0.1.tgz",
-            "integrity": "sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
+            "integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -3615,6 +3638,16 @@
             "peer": true,
             "engines": {
                 "node": ">=0.8.x"
+            }
+        },
+        "node_modules/events-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "bare-events": "^2.7.0"
             }
         },
         "node_modules/express": {
@@ -4272,9 +4305,9 @@
             "license": "MIT"
         },
         "node_modules/json-diff-ts": {
-            "version": "4.8.1",
-            "resolved": "https://registry.npmjs.org/json-diff-ts/-/json-diff-ts-4.8.1.tgz",
-            "integrity": "sha512-Bjs+7bgxkolosAL1n/29XJXCXByAVMdhARkRk32HpJ2IuCvZ/KpqT79ljlYZZRlcN6JE0ygNxRPR+mEMPQBshw==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/json-diff-ts/-/json-diff-ts-4.8.2.tgz",
+            "integrity": "sha512-7LgOTnfK5XnBs0o0AtHTkry5QGZT7cSlAgu5GtiomUeoHqOavAUDcONNm/bCe4Lapt0AHnaidD5iSE+ItvxKkA==",
             "license": "MIT",
             "peer": true
         },
@@ -4554,9 +4587,9 @@
             }
         },
         "node_modules/milsymbol": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/milsymbol/-/milsymbol-3.0.2.tgz",
-            "integrity": "sha512-iYHfum8GCVRpmaRVsRDbw5ZOPY0td3Ltl5+w63caxA2iecS0o1alDnUFUSKaf+Tn8LmA0eUEcSglWR0sLgIDQw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/milsymbol/-/milsymbol-3.0.3.tgz",
+            "integrity": "sha512-Fy/32WaGwitTTaILyLVxsh/pHsiBVKKieC0Ply/LRWLrOGivOB96WjGXSRWlWmXLI+wfoO6/vDfjwR7tyP47fA==",
             "license": "MIT",
             "peer": true
         },
@@ -4943,9 +4976,9 @@
             "peer": true
         },
         "node_modules/protobufjs": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
-            "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "peer": true,
@@ -5400,17 +5433,15 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.22.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-            "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+            "version": "2.23.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+            "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
+                "events-universal": "^1.0.0",
                 "fast-fifo": "^1.3.2",
                 "text-decoder": "^1.1.0"
-            },
-            "optionalDependencies": {
-                "bare-events": "^2.2.0"
             }
         },
         "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     },
     "dependencies": {
         "@sinclair/typebox": "^0.34.0",
-        "@tak-ps/etl": "^9.9.0"
+        "@tak-ps/etl": "^9.22.0"
     }
 }

--- a/task.ts
+++ b/task.ts
@@ -1,5 +1,5 @@
 import { Static, Type, TSchema } from '@sinclair/typebox';
-import ETL, { Event, SchemaType, handler as internal, local, InvocationType, DataFlowType, InputFeatureCollection } from '@tak-ps/etl';
+import ETL, { Event, SchemaType, handler as internal, local, InvocationType, DataFlowType } from '@tak-ps/etl';
 import * as net from 'net';
 
 const Env = Type.Object({
@@ -216,7 +216,15 @@ export default class Task extends ETL {
             }
             
             // Create features from all cached stations
-            const features: Static<typeof InputFeatureCollection>['features'] = [];
+            const features: Array<{
+                id: string;
+                type: 'Feature';
+                properties: Record<string, unknown>;
+                geometry: {
+                    type: 'Point';
+                    coordinates: [number, number, number];
+                };
+            }> = [];
             for (const [, station] of this.stationCache.entries()) {
                 const callsign = station.from.replace(' ', '');
                 const uid = `APRS.${callsign}`;
@@ -253,8 +261,8 @@ export default class Task extends ETL {
                 });
             }
             
-            const fc: Static<typeof InputFeatureCollection> = {
-                type: 'FeatureCollection',
+            const fc = {
+                type: 'FeatureCollection' as const,
                 features
             };
             


### PR DESCRIPTION
## Summary
Updates the `@tak-ps/etl` dependency from version 9.9.0 to 9.22.0 to prevent ETL Layer Get operations from failing with schema errors.

## Changes
- **package.json**: Updated `@tak-ps/etl` dependency to `^9.22.0`
- **task.ts**: 
  - Removed `InputFeatureCollection` from imports (no longer exported in v9.22.0)
  - Replaced `InputFeatureCollection` type references with explicit feature array type
  - Fixed TypeScript compilation errors
  - Resolved ESLint warnings by using specific types instead of `any`

## Testing
- ✅ `npm install` - Dependencies installed successfully
- ✅ `npm run build` - TypeScript compilation passes
- ✅ `npm run lint` - ESLint passes without warnings

## Impact
This update ensures compatibility with the latest ETL framework and prevents schema-related failures in ETL Layer Get operations.
